### PR TITLE
ci: skip dependabot in python ci jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci"
     open-pull-requests-limit: 5

--- a/.github/workflows/ci-multiplatform.yml
+++ b/.github/workflows/ci-multiplatform.yml
@@ -25,7 +25,14 @@ env:
   TEST_DIR: tests
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: "!(github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/github_actions/'))"
+    steps:
+      - run: echo "Running CI"
+
   lint:
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -49,6 +56,7 @@ jobs:
         run: mypy ${{ env.SRC_DIR }} --ignore-missing-imports
 
   security:
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -75,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    needs: lint
+    needs: [gate, lint]
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +121,7 @@ jobs:
 
   # Platform-specific smoke tests
   platform-smoke-tests:
-    needs: test
+    needs: [gate, test]
     strategy:
       fail-fast: false
       matrix:
@@ -295,7 +303,7 @@ jobs:
           python -c "import platform; print(f'Platform: {platform.system()}'); print(f'Python: {platform.python_version()}'); print(f'Architecture: {platform.machine()}')"
 
   build:
-    needs: [lint, test, platform-smoke-tests]
+    needs: [gate, lint, test, platform-smoke-tests]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -341,12 +349,16 @@ jobs:
 
   # Summary job to check overall status
   ci-success:
-    needs: [lint, security, test, platform-smoke-tests, build]
+    needs: [gate, lint, security, test, platform-smoke-tests, build]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check CI status
         run: |
+          if [ "${{ needs.gate.result }}" == "skipped" ]; then
+            echo "✅ CI skipped (dependabot github-actions PR)"
+            exit 0
+          fi
           if [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.security.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \

--- a/.github/workflows/ci-multiplatform.yml
+++ b/.github/workflows/ci-multiplatform.yml
@@ -23,6 +23,8 @@ env:
   DEFAULT_PYTHON: "3.12"
   SRC_DIR: src/nmea_gps_emulator
   TEST_DIR: tests
+  # Ignored vulnerabilities in pip-audit (transitive deps, not in distributed package)
+  PIP_AUDIT_IGNORE: "--ignore-vuln CVE-2026-4539"
 
 jobs:
   gate:
@@ -75,7 +77,7 @@ jobs:
           pip install pip-audit
 
       - name: Run pip-audit
-        run: pip-audit
+        run: pip-audit --skip-editable ${{ env.PIP_AUDIT_IGNORE }}
 
       - name: Check for secrets (Gitleaks)
         uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/ci-multiplatform.yml
+++ b/.github/workflows/ci-multiplatform.yml
@@ -80,7 +80,7 @@ jobs:
         run: pip-audit --skip-editable ${{ env.PIP_AUDIT_IGNORE }}
 
       - name: Check for secrets (Gitleaks)
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,14 @@ env:
   TEST_DIR: tests
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: "!(github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/github_actions/'))"
+    steps:
+      - run: echo "Running CI"
+
   lint:
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -49,6 +56,7 @@ jobs:
         run: mypy ${{ env.SRC_DIR }} --ignore-missing-imports
 
   security:
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -75,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    needs: lint
+    needs: [gate, lint]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -108,7 +116,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
-    needs: [lint, test]
+    needs: [gate, lint, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ env:
   DEFAULT_PYTHON: "3.12"
   SRC_DIR: src/nmea_gps_emulator
   TEST_DIR: tests
+  # Ignored vulnerabilities in pip-audit (transitive deps, not in distributed package)
+  PIP_AUDIT_IGNORE: "--ignore-vuln CVE-2026-4539"
 
 jobs:
   gate:
@@ -75,7 +77,7 @@ jobs:
           pip install pip-audit
 
       - name: Run pip-audit
-        run: pip-audit
+        run: pip-audit --skip-editable ${{ env.PIP_AUDIT_IGNORE }}
 
       - name: Check for secrets (Gitleaks)
         uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: pip-audit --skip-editable ${{ env.PIP_AUDIT_IGNORE }}
 
       - name: Check for secrets (Gitleaks)
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 .vscode/
 .claude/
+.kiro/
 
 # Python
 __pycache__/
@@ -13,6 +14,7 @@ venv/
 .ruff_cache/
 python/
 dist/
+.mypy_cache/
 
 # Pytest
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     - id: detect-private-key
       exclude: ^tests/
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.10
+  rev: v0.15.8
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ classifiers = [
     "Topic :: System :: Emulators",
 ]
 dependencies = [
-    "psutil>=7.1",
+    "psutil>=7.2",
     "pyproj>=3.7",
     "pyserial>=3.5",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.14",
+    "ruff>=0.15",
     "pre-commit",
 ]
 

--- a/src/nmea_gps_emulator/__init__.py
+++ b/src/nmea_gps_emulator/__init__.py
@@ -1,3 +1,3 @@
 """NMEA GPS Emulator - A GPS receiver emulator that generates NMEA 0183 sentences."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
- Skipped dependabot in python ci jobs
- Ignored vulnerabilities in pip-audit (transitive deps, not in distributed package)
- Bumped `psutil>=7.2` and `ruff>=0.15`